### PR TITLE
Prevent interface labels displaying upside-down. Prep for dynamic properties. 

### DIFF
--- a/app/css/graphite.css
+++ b/app/css/graphite.css
@@ -16,8 +16,8 @@
 .n-topology.n-topology-blue .badge-color-fg {
   fill: #ffffff;
   stroke: #0386d2;
-  /*stroke-width: 16px;
-  stroke-linejoin: round;*/
+  stroke-width: 16px;
+  stroke-linejoin: round;
 }
 .n-topology.n-topology-dark .badge-color-fg {
   fill: #00a9ff;
@@ -47,12 +47,9 @@
   text-anchor: start;
   alignment-baseline: text-after-edge;
 }
-.n-topology .label-text-anchor-middle {
-  text-anchor: middle;
-}
 .n-topology .label-text-anchor-end {
   text-anchor: end;
-  alignment-baseline: text-after-edge;
+  alignment-baseline: text-before-edge;
 }
 
 .label-link-align-start {
@@ -64,7 +61,7 @@
 
 .label-link-align-end {
   text-anchor: end;
-  alignment-baseline: text-after-edge;
+  alignment-baseline: text-before-edge;
   transform-box: fill-box;
   transform-origin: 100% 0%;
 }

--- a/app/css/graphite.css
+++ b/app/css/graphite.css
@@ -13,6 +13,36 @@
 .n-topology.n-topology-yellow .label-text-color-fg {
   fill: #ffc200;
 }
+.n-topology.n-topology-blue .badge-color-fg {
+  fill: #ffffff;
+  stroke: #0386d2;
+  /*stroke-width: 16px;
+  stroke-linejoin: round;*/
+}
+.n-topology.n-topology-dark .badge-color-fg {
+  fill: #00a9ff;
+  stroke: #00a9ff;
+  stroke-width: 16px;
+  stroke-linejoin: round;
+}
+.n-topology.n-topology-green .badge-color-fg {
+  fill: #26999e;
+  stroke: #26999e;
+  stroke-width: 16px;
+  stroke-linejoin: round;
+}
+.n-topology.n-topology-slate .badge-color-fg {
+  fill: #ffffff;
+  stroke: #ffffff;
+  stroke-width: 16px;
+  stroke-linejoin: round;
+}
+.n-topology.n-topology-yellow .badge-color-fg {
+  fill: #ffc200;
+  stroke: #ffc200;
+  stroke-width: 16px;
+  stroke-linejoin: round;
+}
 .n-topology .label-text-anchor-start {
   text-anchor: start;
   alignment-baseline: text-after-edge;

--- a/app/css/graphite.css
+++ b/app/css/graphite.css
@@ -52,14 +52,14 @@
   alignment-baseline: text-before-edge;
 }
 
-.label-link-align-start {
+.n-topology .label-link-align-start {
   text-anchor: start;
   alignment-baseline: text-after-edge;
   transform-box: fill-box;
   transform-origin: 0% 100%;
 }
 
-.label-link-align-end {
+.n-topology .label-link-align-end {
   text-anchor: end;
   alignment-baseline: text-before-edge;
   transform-box: fill-box;

--- a/app/css/graphite.css
+++ b/app/css/graphite.css
@@ -54,3 +54,17 @@
   text-anchor: end;
   alignment-baseline: text-after-edge;
 }
+
+.label-link-align-start {
+  text-anchor: start;
+  alignment-baseline: text-after-edge;
+  transform-box: fill-box;
+  transform-origin: 0% 100%;
+}
+
+.label-link-align-end {
+  text-anchor: end;
+  alignment-baseline: text-after-edge;
+  transform-box: fill-box;
+  transform-origin: 100% 0%;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -49,7 +49,7 @@
                 </h3>
               </div>
             </div>
-            <div class="panel-body" id="topology-container"></div>
+            <div class="panel-body" id="topology-container" style="padding: 0"></div>
             <div class="panel-footer">
               <ul class="nav nav-pills">
                 <li role="presentation" class="disabled"><a href="#">Layout</a></li>

--- a/app/js/clab.js
+++ b/app/js/clab.js
@@ -45,6 +45,10 @@ function if_shortname(ifname) {
   return ifname;
 }
 
+function if_number(ifname) {
+  return ifname.replace(/^[A-z]+/,'');
+}
+
 function port_mode_node_name(n, i) {
   return i + "@" + n;
 }
@@ -196,8 +200,8 @@ function convert_clab_topology_data_to_cmt(c){
     var tgt_i = node_id_map[l["z"]["node"]];
     var src_d_name = l["a"]["node"];
     var tgt_d_name = l["z"]["node"];
-    var src_i_name = l["a"]["interface"];
-    var tgt_i_name = l["z"]["interface"];
+    var src_i_name = if_number(l["a"]["interface"]);
+    var tgt_i_name = if_number(l["z"]["interface"]);
     if (node_id_map.hasOwnProperty(port_mode_node_name(l["a"]["node"], l["a"]["interface"]))) {
       src_i = node_id_map[port_mode_node_name(l["a"]["node"], l["a"]["interface"])];
       src_i_name = "";

--- a/app/js/clab.js
+++ b/app/js/clab.js
@@ -45,10 +45,6 @@ function if_shortname(ifname) {
   return ifname;
 }
 
-function if_number(ifname) {
-  return ifname.replace(/^[A-z]+/,'');
-}
-
 function port_mode_node_name(n, i) {
   return i + "@" + n;
 }
@@ -200,8 +196,8 @@ function convert_clab_topology_data_to_cmt(c){
     var tgt_i = node_id_map[l["z"]["node"]];
     var src_d_name = l["a"]["node"];
     var tgt_d_name = l["z"]["node"];
-    var src_i_name = if_number(l["a"]["interface"]);
-    var tgt_i_name = if_number(l["z"]["interface"]);
+    var src_i_name = l["a"]["interface"];
+    var tgt_i_name = l["z"]["interface"];
     if (node_id_map.hasOwnProperty(port_mode_node_name(l["a"]["node"], l["a"]["interface"]))) {
       src_i = node_id_map[port_mode_node_name(l["a"]["node"], l["a"]["interface"])];
       src_i_name = "";

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -61,6 +61,8 @@
               linkType: 'curve', // also: parallel
               sourcelabel: 'model.srcIfName',
               targetlabel: 'model.tgtIfName',
+              sourceIPlabel: 'model.srcIfIP',
+              targetIPlabel: 'model.tgtIfIP',
             }
           }
         }
@@ -386,8 +388,24 @@
         properties: {
             sourcelabel: null,
             targetlabel: null,
-            sourceIP: null,
-            targetIP: null,
+            sourceIPlabel: {
+              get: function () {
+                if (this.model().get('srcIfIP') != null) {
+                  return this.model().get('srcIfIP');
+                } else {
+                  return "";
+                }
+              }
+            },
+            targetIPlabel: {
+              get: function () {
+                if (this.model().get('tgtIfIP') != null) {
+                  return this.model().get('tgtIfIP');
+                } else {
+                  return "";
+                }
+              }
+            },
         },
         view: function (view) {
             view.content.push({
@@ -475,9 +493,7 @@
                     position_link_badge(badge, badgeBg, line_int.start, stageScale)
 
                     var ipLabel = this.view('sourceIP');
-                    if (this.sourceIP() != null) {
-                      ipLabel.set('text', this.sourceIP());
-                    }
+                    ipLabel.set('text', this.sourceIPlabel());
                     ipLabel.setStyle('font-size', 10 * stageScale);
                     align_link_label(ipLabel, line_ip.start, angle, "source");
                 }
@@ -491,9 +507,7 @@
                     position_link_badge(badge, badgeBg, line_int.end, stageScale)
 
                     var ipLabel = this.view('targetIP');
-                    if (this.targetIP() != null) {
-                      ipLabel.set('text', this.targetIP());
-                    }
+                    ipLabel.set('text', this.targetIPlabel());
                     ipLabel.setStyle('font-size', 10 * stageScale);
                     align_link_label(ipLabel, line_ip.end, angle, "target");
                 }
@@ -508,15 +522,11 @@
               },
               showIP: function () {
                 var srcLabel = this.view('sourceIP');
-                if (this.model().get("srcIfIP") != null) {
-                  srcLabel.set('text', this.model().get("srcIfIP"));
-                  srcLabel.visible(true);
-                }
+                srcLabel.set('text', this.sourceIPlabel());
+                srcLabel.visible(true);
                 var tgtLabel = this.view('targetIP');
-                if (this.model().get("tgtIfIP") != null) {
-                  tgtLabel.set('text', this.model().get("tgtIfIP"));
-                  tgtLabel.visible(true);
-                }
+                tgtLabel.set('text', this.targetIPlabel());
+                tgtLabel.visible(true);
               },
               hideIP: function () {
                 this.view('sourceIP').visible(false);

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -573,6 +573,7 @@
             topologyContainer: {},
             topology: {},
             linkInstanceClass: '',
+            currentLayout: 'auto',
             actionBar: {}
         },
         methods: {
@@ -594,6 +595,30 @@
               // Attach it to the document
               this.topology.attach(this);
               this.linkInstanceClass = this.topology.linkInstanceClass();
+            },
+            layout_horizontal: function () {
+              if (this.currentLayout === 'vertical') {
+                  return;
+              };
+              this.currentLayout = 'vertical';
+              var layout = this.topology.getLayout('hierarchicalLayout');
+              layout.direction('vertical');
+              layout.levelBy(function(node, model) {
+                  return model.get('layerSortPreference');
+              });
+              this.topology.activateLayout('hierarchicalLayout');
+            },
+            layout_vertical: function () {
+              if (this.currentLayout === 'horizontal') {
+                  return;
+              };
+              this.currentLayout = 'horizontal';
+              var layout = this.topology.getLayout('hierarchicalLayout');
+              layout.direction('horizontal');
+              layout.levelBy(function(node, model) {
+                  return model.get('layerSortPreference');
+              });
+              this.topology.activateLayout('hierarchicalLayout');
             },
             toggle_link_label_types: function () {
               switch (this.linkInstanceClass) {
@@ -620,38 +645,20 @@
 
 (function (nx) {
 
-    var currentLayout = 'auto'
+    var app; // TopologyApp
 
     horizontal = function() {
-        if (currentLayout === 'horizontal') {
-            return;
-        };
-        currentLayout = 'horizontal';
         document.getElementById("nav-auto").className = "";
         document.getElementById("nav-horizontal").className = "active";
         document.getElementById("nav-vertical").className = "";
-        var layout = topo.getLayout('hierarchicalLayout');
-        layout.direction('horizontal');
-        layout.levelBy(function(node, model) {
-            return model.get('layerSortPreference');
-        });
-        topo.activateLayout('hierarchicalLayout');
+        app.layout_horizontal();
     };
 
     vertical = function() {
-        if (currentLayout === 'vertical') {
-            return;
-        };
-        currentLayout = 'vertical';
         document.getElementById("nav-auto").className = "";
         document.getElementById("nav-horizontal").className = "";
         document.getElementById("nav-vertical").className = "active";
-        var layout = topo.getLayout('hierarchicalLayout');
-        layout.direction('vertical');
-        layout.levelBy(function(node, model) {
-          return model.get('layerSortPreference');
-        });
-        topo.activateLayout('hierarchicalLayout');
+        app.layout_vertical();
     };
 
     // Identify topology to load
@@ -703,7 +710,7 @@
         }
         if (topologyData.nodes.length > 0) {
           // initialize a new application instance
-          var app = new TopologyApp();
+          app = new TopologyApp();
           app.start(topologyData);
           //assign the app to the <div>
           app.container(document.getElementById('topology-container'));

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -852,7 +852,7 @@
         }
         if (topologyData.hasOwnProperty("type") && topologyData.type == "clab" && topologyData.hasOwnProperty("name")) {
           document.title = topologyData.name + " - " + topologyData.type + "@" + window.location.hostname;
-          document.getElementById("topology-type").innerHTML = "ContainerLab Topology";
+          document.getElementById("topology-type").innerHTML = "Containerlab Topology";
           if (topologyData.name != "") {
             document.getElementById("topology-name").innerHTML = topologyData.name;
           } else {

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -395,6 +395,9 @@
                 } else {
                   return "";
                 }
+              },
+              set: function (ip) {
+                this.model().set('srcIfIP', ip);
               }
             },
             targetIPlabel: {
@@ -404,6 +407,9 @@
                 } else {
                   return "";
                 }
+              },
+              set: function (ip) {
+                this.model().set('tgtIfIP', ip);
               }
             },
         },
@@ -693,15 +699,17 @@
                             node.eachLink(
                               function (link) {
                                 // find out if current node is source or target of the link
-                                if (link.get('sourceNode').model().get('name') == n) {
+                                if (link.sourceNode().model().get('name') == n) {
+                                  var ifname = link.sourcelabel();
                                   // find out if we have data for this interface name
-                                  if (data.nodes[n]['interfaces'].hasOwnProperty(link.get('sourcelabel'))) {
-                                    link.model().set("srcIfIP", data.nodes[n]['interfaces'][link.get('sourcelabel')]['ipv4']);
+                                  if (data.nodes[n].interfaces.hasOwnProperty(ifname)) {
+                                    link.sourceIPlabel(data.nodes[n].interfaces[ifname].ipv4);
                                   }
-                                } else if (link.get('targetNode').model().get('name') == n) {
+                                } else if (link.targetNode().model().get('name') == n) {
+                                  var ifname = link.targetlabel();
                                   // find out if we have data for this interface name
-                                  if (data.nodes[n]['interfaces'].hasOwnProperty(link.get('targetlabel'))) {
-                                    link.model().set("tgtIfIP", data.nodes[n]['interfaces'][link.get('targetlabel')]['ipv4']);
+                                  if (data.nodes[n].interfaces.hasOwnProperty(ifname)) {
+                                    link.targetIPlabel(data.nodes[n].interfaces[ifname].ipv4);
                                   }
                                 }
                                 if (typeof link.showIP === 'function') {

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -334,13 +334,13 @@
                 name: 'source',
                 type: 'nx.graphic.Text',
                 props: {
-                    'class': 'sourcelabel label-text-color-fg label-text-anchor-start'
+                    'class': 'sourcelabel label-text-color-fg label-link-align-start'
                 }
             }, {
                 name: 'target',
                 type: 'nx.graphic.Text',
                 props: {
-                    'class': 'targetlabel label-text-color-fg label-text-anchor-end'
+                    'class': 'targetlabel label-text-color-fg label-link-align-end'
                 }
             });
             
@@ -358,33 +358,53 @@
                 
                 this.inherited();
                 
-                
                 var el, point;
                 
                 var line = this.line();
                 var angle = line.angle();
+                var angle_flip = angle + 180;
                 var stageScale = this.stageScale();
                 
                 // pad line
-                line = line.pad(24 * stageScale, 24 * stageScale);
+                var line_int = line.pad(35 * stageScale, 35 * stageScale);
                 
                 if (this.sourcelabel()) {
                     el = this.view('source');
-                    point = line.start;
+                    el.set('text', this.sourcelabel());
+                    point = line_int.start;
                     el.set('x', point.x);
                     el.set('y', point.y);
-                    el.set('text', this.sourcelabel());
-                    el.set('transform', 'rotate(' + angle + ' ' + point.x + ',' + point.y + ')');
+                    if (angle > 90 || angle < -90) {
+                      el.setStyle('text-anchor', 'end');
+                      el.setStyle('transform-origin', '100% 0%');
+                      el.setStyle('alignment-baseline', 'text-before-edge');
+                      el.set('transform', 'rotate(' + angle_flip + ')');
+                    } else {
+                      el.setStyle('text-anchor', 'start');
+                      el.setStyle('transform-origin', '0% 100%');
+                      el.setStyle('alignment-baseline', 'text-after-edge');
+                      el.set('transform', 'rotate(' + angle + ')');
+                    }
                     el.setStyle('font-size', 12 * stageScale);
                 }
                 
                 if (this.targetlabel()) {
                     el = this.view('target');
-                    point = line.end;
+                    el.set('text', this.targetlabel());
+                    point = line_int.end;
                     el.set('x', point.x);
                     el.set('y', point.y);
-                    el.set('text', this.targetlabel());
-                    el.set('transform', 'rotate(' + angle + ' ' + point.x + ',' + point.y + ')');
+                    if (angle > 90 || angle < -90) {
+                      el.setStyle('text-anchor', 'start');
+                      el.setStyle('transform-origin', '0% 100%');
+                      el.setStyle('alignment-baseline', 'text-after-edge');
+                      el.set('transform', 'rotate(' + angle_flip + ')');
+                    } else {
+                      el.setStyle('text-anchor', 'end');
+                      el.setStyle('transform-origin', '100% 0%');
+                      el.setStyle('alignment-baseline', 'text-before-edge');
+                      el.set('transform', 'rotate(' + angle + ')');
+                    }
                     el.setStyle('font-size', 12 * stageScale);
                 }
             }

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -417,10 +417,7 @@
                             y: 1
                         }
                     }
-                ],
-                props: {
-                    'alignment-baseline': 'after-edge',
-                }
+                ]
               },
               {
                 name: 'targetBadge',
@@ -442,10 +439,7 @@
                             y: 1
                         }
                     }
-                ],
-                props: {
-                    'alignment-baseline': 'after-edge',
-                }
+                ]
               },
               {
                 name: 'sourceIP',

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -358,54 +358,25 @@
                 
                 this.inherited();
                 
-                var el, point;
-                
                 var line = this.line();
                 var angle = line.angle();
-                var angle_flip = angle + 180;
                 var stageScale = this.stageScale();
                 
                 // pad line
                 var line_int = line.pad(35 * stageScale, 35 * stageScale);
                 
                 if (this.sourcelabel()) {
-                    el = this.view('source');
-                    el.set('text', this.sourcelabel());
-                    point = line_int.start;
-                    el.set('x', point.x);
-                    el.set('y', point.y);
-                    if (angle > 90 || angle < -90) {
-                      el.setStyle('text-anchor', 'end');
-                      el.setStyle('transform-origin', '100% 0%');
-                      el.setStyle('alignment-baseline', 'text-before-edge');
-                      el.set('transform', 'rotate(' + angle_flip + ')');
-                    } else {
-                      el.setStyle('text-anchor', 'start');
-                      el.setStyle('transform-origin', '0% 100%');
-                      el.setStyle('alignment-baseline', 'text-after-edge');
-                      el.set('transform', 'rotate(' + angle + ')');
-                    }
-                    el.setStyle('font-size', 12 * stageScale);
+                    var label = this.view('source');
+                    label.set('text', this.sourcelabel());
+                    label.setStyle('font-size', 12 * stageScale);
+                    align_link_label(label, line_int.start, angle, "source");
                 }
                 
                 if (this.targetlabel()) {
-                    el = this.view('target');
-                    el.set('text', this.targetlabel());
-                    point = line_int.end;
-                    el.set('x', point.x);
-                    el.set('y', point.y);
-                    if (angle > 90 || angle < -90) {
-                      el.setStyle('text-anchor', 'start');
-                      el.setStyle('transform-origin', '0% 100%');
-                      el.setStyle('alignment-baseline', 'text-after-edge');
-                      el.set('transform', 'rotate(' + angle_flip + ')');
-                    } else {
-                      el.setStyle('text-anchor', 'end');
-                      el.setStyle('transform-origin', '100% 0%');
-                      el.setStyle('alignment-baseline', 'text-before-edge');
-                      el.set('transform', 'rotate(' + angle + ')');
-                    }
-                    el.setStyle('font-size', 12 * stageScale);
+                    label = this.view('target');
+                    label.set('text', this.targetlabel());
+                    label.setStyle('font-size', 12 * stageScale);
+                    align_link_label(label, line_int.end, angle, "target");
                 }
             }
         }
@@ -489,80 +460,32 @@
                 this.inherited();
                 var line = this.line();
                 var angle = line.angle();
-                var angle_flip = angle + 180;
                 var stageScale = this.stageScale();
-                var ipLabel;
                 var line_int = line.pad(50 * stageScale, 50 * stageScale);
                 var line_ip = line.pad(75 * stageScale, 75 * stageScale);
                 if (this.sourcelabel()) {
-                    var sourceBadge = this.view('sourceBadge');
-                    var sourceText = this.view('sourceText');
-                    var sourceBg = this.view('sourceBg');
-                    var point_int, point_ip;
-                    sourceText.sets({
-                      text: if_number(this.sourcelabel()),
-                    });
-                    ipLabel = this.view('sourceIP');
+                    var badge = this.view('sourceBadge');
+                    var badgeBg = this.view('sourceBg');
+                    var badgeLabel = this.view('sourceText');
+                    badgeLabel.set('text', if_number(this.sourcelabel()));
+                    position_link_badge(badge, badgeBg, line_int.start, stageScale)
+
+                    var ipLabel = this.view('sourceIP');
                     ipLabel.set('text', "192.168.1.101/24");
-                    //TODO: accommodate larger text label
-                    sourceBg.sets({ width: 8, visible: true });
-                    sourceBg.setTransform(8 / -2);
-                    point_int = line_int.start;
-                    if (stageScale) {
-                        sourceBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ' + 'scale (' + stageScale + ') ');
-                    } else {
-                        sourceBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ');
-                    }
-                    point_ip = line_ip.start;
-                    ipLabel.set('x', point_ip.x);
-                    ipLabel.set('y', point_ip.y);
-                    if (angle > 90 || angle < -90) {
-                      ipLabel.setStyle('text-anchor', 'end');
-                      ipLabel.setStyle('transform-origin', '100% 0%');
-                      ipLabel.setStyle('alignment-baseline', 'text-before-edge');
-                      ipLabel.set('transform', 'rotate(' + angle_flip + ')');
-                    } else {
-                      ipLabel.setStyle('text-anchor', 'start');
-                      ipLabel.setStyle('transform-origin', '0% 100%');
-                      ipLabel.setStyle('alignment-baseline', 'text-after-edge');
-                      ipLabel.set('transform', 'rotate(' + angle + ')');
-                    }
                     ipLabel.setStyle('font-size', 10 * stageScale);
-                    
+                    align_link_label(ipLabel, line_ip.start, angle, "source");
                 }
                 if (this.targetlabel()) {
-                    var targetBadge = this.view('targetBadge');
-                    var targetText = this.view('targetText');
-                    var targetBg = this.view('targetBg');
-                    var point_int, point_ip;
-                    targetText.sets({
-                        text: if_number(this.targetlabel()),
-                    });
-                    ipLabel = this.view('targetIP');
+                    var badge = this.view('targetBadge');
+                    var badgeLabel = this.view('targetText');
+                    var badgeBg = this.view('targetBg');
+                    badgeLabel.set('text', if_number(this.targetlabel()));
+                    position_link_badge(badge, badgeBg, line_int.end, stageScale)
+
+                    var ipLabel = this.view('targetIP');
                     ipLabel.set('text', "192.168.1.101/24");
-                    targetBg.sets({ width: 8, visible: true });
-                    targetBg.setTransform(8 / -2);
-                    point_int = line_int.end;
-                    if (stageScale) {
-                        targetBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ' + 'scale (' + stageScale + ') ');
-                    } else {
-                        targetBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ');
-                    }
-                    point_ip = line_ip.end;
-                    ipLabel.set('x', point_ip.x);
-                    ipLabel.set('y', point_ip.y);
-                    if (angle > 90 || angle < -90) {
-                      ipLabel.setStyle('text-anchor', 'start');
-                      ipLabel.setStyle('transform-origin', '0% 100%');
-                      ipLabel.setStyle('alignment-baseline', 'text-after-edge');
-                      ipLabel.set('transform', 'rotate(' + angle_flip + ')');
-                    } else {
-                      ipLabel.setStyle('text-anchor', 'end');
-                      ipLabel.setStyle('transform-origin', '100% 0%');
-                      ipLabel.setStyle('alignment-baseline', 'text-before-edge');
-                      ipLabel.set('transform', 'rotate(' + angle + ')');
-                    }
                     ipLabel.setStyle('font-size', 10 * stageScale);
+                    align_link_label(ipLabel, line_ip.end, angle, "target");
                 }
                 this.view("sourceBadge").visible(true);
                 this.view("sourceBg").visible(true);
@@ -570,6 +493,8 @@
                 this.view("targetBadge").visible(true);
                 this.view("targetBg").visible(true);
                 this.view("targetText").visible(true);
+                this.view("sourceIP").visible(true);
+                this.view("targetIP").visible(true);
               }
           }
       });
@@ -744,6 +669,52 @@
   
   function if_number(ifname) {
     return ifname.replace(/^[A-z]+/,'');
+  }
+  
+  function align_link_label(label, point, angle, which_end) {
+    var angle_flip = angle + 180;
+    label.set('x', point.x);
+    label.set('y', point.y);
+    switch (which_end) {
+    case "source":
+      if (angle > 90 || angle < -90) {
+        label.setStyle('text-anchor', 'end');
+        label.setStyle('transform-origin', '100% 0%');
+        label.setStyle('alignment-baseline', 'text-before-edge');
+        label.set('transform', 'rotate(' + angle_flip + ')');
+      } else {
+        label.setStyle('text-anchor', 'start');
+        label.setStyle('transform-origin', '0% 100%');
+        label.setStyle('alignment-baseline', 'text-after-edge');
+        label.set('transform', 'rotate(' + angle + ')');
+      }
+      break;
+    case "target":
+      if (angle > 90 || angle < -90) {
+        label.setStyle('text-anchor', 'start');
+        label.setStyle('transform-origin', '0% 100%');
+        label.setStyle('alignment-baseline', 'text-after-edge');
+        label.set('transform', 'rotate(' + angle_flip + ')');
+      } else {
+        label.setStyle('text-anchor', 'end');
+        label.setStyle('transform-origin', '100% 0%');
+        label.setStyle('alignment-baseline', 'text-before-edge');
+        label.set('transform', 'rotate(' + angle + ')');
+      }
+      break;
+    default:
+    }
+  }
+  
+  function position_link_badge(badge, badgeBg, point, stageScale) {
+    //TODO: accommodate larger text label
+    badgeBg.sets({ width: 8, visible: true });
+    badgeBg.setTransform(8 / -2);
+    if (stageScale) {
+        badge.set('transform', 'translate(' + point.x + ',' + point.y + ') ' + 'scale (' + stageScale + ') ');
+    } else {
+        badge.set('transform', 'translate(' + point.x + ',' + point.y + ') ');
+    }
   }
 
 })(nx);

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -477,6 +477,7 @@
         methods: {
             init: function (args) {
                 this.inherited(args);
+                this.hideIP();
                 this.topology().fit();
             },
             'setModel': function (model) {

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -469,6 +469,7 @@
                 this.inherited();
                 var line = this.line();
                 var angle = line.angle();
+                var angle_flip = angle + 180;
                 var stageScale = this.stageScale();
                 var ipLabel;
                 var line_int = line.pad(50 * stageScale, 50 * stageScale);
@@ -495,7 +496,17 @@
                     point_ip = line_ip.start;
                     ipLabel.set('x', point_ip.x);
                     ipLabel.set('y', point_ip.y);
-                    ipLabel.set('transform', 'rotate(' + angle + ')');
+                    if (angle > 90 || angle < -90) {
+                      ipLabel.setStyle('text-anchor', 'end');
+                      ipLabel.setStyle('transform-origin', '100% 0%');
+                      ipLabel.setStyle('alignment-baseline', 'text-before-edge');
+                      ipLabel.set('transform', 'rotate(' + angle_flip + ')');
+                    } else {
+                      ipLabel.setStyle('text-anchor', 'start');
+                      ipLabel.setStyle('transform-origin', '0% 100%');
+                      ipLabel.setStyle('alignment-baseline', 'text-after-edge');
+                      ipLabel.set('transform', 'rotate(' + angle + ')');
+                    }
                     ipLabel.setStyle('font-size', 10 * stageScale);
                     
                 }
@@ -520,7 +531,17 @@
                     point_ip = line_ip.end;
                     ipLabel.set('x', point_ip.x);
                     ipLabel.set('y', point_ip.y);
-                    ipLabel.set('transform', 'rotate(' + angle + ')');
+                    if (angle > 90 || angle < -90) {
+                      ipLabel.setStyle('text-anchor', 'start');
+                      ipLabel.setStyle('transform-origin', '0% 100%');
+                      ipLabel.setStyle('alignment-baseline', 'text-after-edge');
+                      ipLabel.set('transform', 'rotate(' + angle_flip + ')');
+                    } else {
+                      ipLabel.setStyle('text-anchor', 'end');
+                      ipLabel.setStyle('transform-origin', '100% 0%');
+                      ipLabel.setStyle('alignment-baseline', 'text-before-edge');
+                      ipLabel.set('transform', 'rotate(' + angle + ')');
+                    }
                     ipLabel.setStyle('font-size', 10 * stageScale);
                 }
                 this.view("sourceBadge").visible(true);

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -570,7 +570,7 @@
             actionBar: {}
         },
         methods: {
-            start: function (cmt) {
+            init_with_cmt: function (cmt) {
               /* TopologyContainer is a nx.ui.Component object that can contain much more things than just a nx.graphic.Topology object.
                We can 'inject' a topology instance inside and interact with it easily
                */
@@ -578,17 +578,25 @@
               this.topologyContainer = new TopologyContainer();
               // topology instance was made in TopologyContainer, but we can invoke its members through 'topology' variable for convenience
               this.topology = this.topologyContainer.topology();
-              this.actionBar = new ActionBar();
               
               // Read topology data from variable
               this.topology.data(cmt);
+              this.linkInstanceClass = this.topology.linkInstanceClass();
+              this.devicePropertiesShown = false;
+            },
+            add_action_bar: function () {
+              this.actionBar = new ActionBar();
               this.actionBar.assignTopology(this.topology);
               this.actionBar.assignTopologyApp(this);
               this.actionBar.attach(this);
+            },
+            attach: function () {
               // Attach it to the document
               this.topology.attach(this);
-              this.linkInstanceClass = this.topology.linkInstanceClass();
-              this.devicePropertiesShown = false;
+            },
+            detach: function () {
+              // Attach it to the document
+              this.topology.detach(this);
             },
             layout_horizontal: function () {
               if (this.currentLayout === 'vertical') {
@@ -693,11 +701,15 @@
     const queryString = window.location.search;
     const url_params = new URLSearchParams(queryString);
     var topo_type = "default", topo_name = "default", topo_base = "/default/", topo_url;
+    var showActionBar = false;
     if (url_params.has('type')) {
       topo_type = url_params.get('type');
     }
     if (url_params.has('topo')) {
       topo_name = url_params.get('topo');
+    }
+    if (url_params.has('actionbar')) {
+      showActionBar = true;
     }
     switch (topo_type) {
     case "clab":
@@ -739,9 +751,13 @@
         if (topologyData.nodes.length > 0) {
           // initialize a new application instance
           app = new TopologyApp();
-          app.start(topologyData);
           //assign the app to the <div>
           app.container(document.getElementById('topology-container'));
+          app.init_with_cmt(topologyData);
+          if (showActionBar) {
+            app.add_action_bar();
+          }
+          app.attach();
         } else {
           if (topologyData.type == "clab") {
             // data came from containerlab topology-data.json

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -471,11 +471,11 @@
                     var sourceBg = this.view('sourceBg');
                     var point;
                     sourceText.sets({
-                        text: this.sourcelabel(),
+                      text: this.sourcelabel(),
                     });
                     //TODO: accommodate larger text label
-                    sourceBg.sets({ width: 34, visible: true });
-                    sourceBg.setTransform(34 / -2);
+                    sourceBg.sets({ width: 8, visible: true });
+                    sourceBg.setTransform(8 / -2);
                     point = line.start;
                     if (stageScale) {
                         sourceBadge.set('transform', 'translate(' + point.x + ',' + point.y + ') ' + 'scale (' + stageScale + ') ');
@@ -491,8 +491,8 @@
                     targetText.sets({
                         text: this.targetlabel(),
                     });
-                    targetBg.sets({ width: 34, visible: true });
-                    targetBg.setTransform(34 / -2);
+                    targetBg.sets({ width: 8, visible: true });
+                    targetBg.setTransform(8 / -2);
                     point = line.end;
                     if (stageScale) {
                         targetBadge.set('transform', 'translate(' + point.x + ',' + point.y + ') ' + 'scale (' + stageScale + ') ');

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -421,33 +421,45 @@
                 props: {
                     'alignment-baseline': 'after-edge',
                 }
-            },
-                {
-                    name: 'targetBadge',
-                    type: 'nx.graphic.Group',
-                    content: [
-                        {
-                            name: 'targetBg',
-                            type: 'nx.graphic.Rect',
-                            props: {
-                                'class': 'link-set-circle',
-                                height: 1
-                            }
-                        },
-                        {
-                            name: 'targetText',
-                            type: 'nx.graphic.Text',
-                            props: {
-                                'class': 'link-set-text',
-                                y: 1
-                            }
+              },
+              {
+                name: 'targetBadge',
+                type: 'nx.graphic.Group',
+                content: [
+                    {
+                        name: 'targetBg',
+                        type: 'nx.graphic.Rect',
+                        props: {
+                            'class': 'link-set-circle',
+                            height: 1
                         }
-                    ],
-                    props: {
-                        'alignment-baseline': 'after-edge',
+                    },
+                    {
+                        name: 'targetText',
+                        type: 'nx.graphic.Text',
+                        props: {
+                            'class': 'link-set-text',
+                            y: 1
+                        }
                     }
+                ],
+                props: {
+                    'alignment-baseline': 'after-edge',
                 }
-
+              },
+              {
+                name: 'sourceIP',
+                type: 'nx.graphic.Text',
+                props: {
+                    'class': 'sourcelabel label-text-color-fg label-link-align-start'
+                }
+              }, {
+                name: 'targetIP',
+                type: 'nx.graphic.Text',
+                props: {
+                    'class': 'targetlabel label-text-color-fg label-link-align-end'
+                }
+              }
             );
             return view;
         },
@@ -464,41 +476,58 @@
                 var line = this.line();
                 var angle = line.angle();
                 var stageScale = this.stageScale();
-                line = line.pad(50 * stageScale, 50 * stageScale);
+                var ipLabel;
+                var line_int = line.pad(50 * stageScale, 50 * stageScale);
+                var line_ip = line.pad(75 * stageScale, 75 * stageScale);
                 if (this.sourcelabel()) {
                     var sourceBadge = this.view('sourceBadge');
                     var sourceText = this.view('sourceText');
                     var sourceBg = this.view('sourceBg');
-                    var point;
+                    var point_int, point_ip;
                     sourceText.sets({
                       text: this.sourcelabel(),
                     });
+                    ipLabel = this.view('sourceIP');
+                    ipLabel.set('text', "192.168.1.101/24");
                     //TODO: accommodate larger text label
                     sourceBg.sets({ width: 8, visible: true });
                     sourceBg.setTransform(8 / -2);
-                    point = line.start;
+                    point_int = line_int.start;
                     if (stageScale) {
-                        sourceBadge.set('transform', 'translate(' + point.x + ',' + point.y + ') ' + 'scale (' + stageScale + ') ');
+                        sourceBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ' + 'scale (' + stageScale + ') ');
                     } else {
-                        sourceBadge.set('transform', 'translate(' + point.x + ',' + point.y + ') ');
+                        sourceBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ');
                     }
+                    point_ip = line_ip.start;
+                    ipLabel.set('x', point_ip.x);
+                    ipLabel.set('y', point_ip.y);
+                    ipLabel.set('transform', 'rotate(' + angle + ')');
+                    ipLabel.setStyle('font-size', 10 * stageScale);
+                    
                 }
                 if (this.targetlabel()) {
                     var targetBadge = this.view('targetBadge');
                     var targetText = this.view('targetText');
                     var targetBg = this.view('targetBg');
-                    var point;
+                    var point_int, point_ip;
                     targetText.sets({
                         text: this.targetlabel(),
                     });
+                    ipLabel = this.view('targetIP');
+                    ipLabel.set('text', "192.168.1.101/24");
                     targetBg.sets({ width: 8, visible: true });
                     targetBg.setTransform(8 / -2);
-                    point = line.end;
+                    point_int = line_int.end;
                     if (stageScale) {
-                        targetBadge.set('transform', 'translate(' + point.x + ',' + point.y + ') ' + 'scale (' + stageScale + ') ');
+                        targetBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ' + 'scale (' + stageScale + ') ');
                     } else {
-                        targetBadge.set('transform', 'translate(' + point.x + ',' + point.y + ') ');
+                        targetBadge.set('transform', 'translate(' + point_int.x + ',' + point_int.y + ') ');
                     }
+                    point_ip = line_ip.end;
+                    ipLabel.set('x', point_ip.x);
+                    ipLabel.set('y', point_ip.y);
+                    ipLabel.set('transform', 'rotate(' + angle + ')');
+                    ipLabel.setStyle('font-size', 10 * stageScale);
                 }
                 this.view("sourceBadge").visible(true);
                 this.view("sourceBg").visible(true);

--- a/app/js/nextui.js
+++ b/app/js/nextui.js
@@ -480,7 +480,7 @@
                     var sourceBg = this.view('sourceBg');
                     var point_int, point_ip;
                     sourceText.sets({
-                      text: this.sourcelabel(),
+                      text: if_number(this.sourcelabel()),
                     });
                     ipLabel = this.view('sourceIP');
                     ipLabel.set('text', "192.168.1.101/24");
@@ -516,7 +516,7 @@
                     var targetBg = this.view('targetBg');
                     var point_int, point_ip;
                     targetText.sets({
-                        text: this.targetlabel(),
+                        text: if_number(this.targetlabel()),
                     });
                     ipLabel = this.view('targetIP');
                     ipLabel.set('text', "192.168.1.101/24");
@@ -720,7 +720,12 @@
             }
         }
     });
-    
+
+  
+  function if_number(ifname) {
+    return ifname.replace(/^[A-z]+/,'');
+  }
+
 })(nx);
 
 (function (nx) {


### PR DESCRIPTION
Interface label improvements:

- Same color as node labels, follow display theme
- Align opposite labels on the link to different sides of the link, to prevent overlapping on tighter diagrams
- When interface labels are tracking rotation of their respective link and detect it is going beyond 90deg, they now automatically flip, thus preventing from being displayed upside-down.

Plus, prep work for displaying dynamic properties on nodes and links.